### PR TITLE
feat: Add comprehensive Forum API tests and fix permission issues

### DIFF
--- a/backend/genfit_django/api/separate_views/forum_comments.py
+++ b/backend/genfit_django/api/separate_views/forum_comments.py
@@ -30,6 +30,8 @@ def add_comment(request, thread_id):
 @permission_classes([IsAuthenticated])
 def delete_comment(request, comment_id):
     comment = get_object_or_404(Comment, pk=comment_id)
+    if comment.author != request.user:
+        return Response({'error': 'You do not have permission to perform this action.'}, status=status.HTTP_403_FORBIDDEN)
 
     # Use serializer's delete logic
     serializer = CommentSerializer()
@@ -43,6 +45,8 @@ def delete_comment(request, comment_id):
 @permission_classes([IsAuthenticated])
 def update_comment(request, comment_id):
     comment = get_object_or_404(Comment, pk=comment_id)
+    if comment.author != request.user:
+        return Response({'error': 'You do not have permission to perform this action.'}, status=status.HTTP_403_FORBIDDEN)
     serializer = CommentSerializer(comment, data=request.data, partial=False)  # Full update
     if serializer.is_valid():
         serializer.save()
@@ -99,6 +103,8 @@ def add_subcomment(request, comment_id):
 @permission_classes([IsAuthenticated])
 def delete_subcomment(request, subcomment_id):
     subcomment = get_object_or_404(Subcomment, pk=subcomment_id)
+    if subcomment.author != request.user:
+        return Response({'error': 'You do not have permission to perform this action.'}, status=status.HTTP_403_FORBIDDEN)
 
     # Use serializer's custom delete method
     serializer = SubcommentSerializer()
@@ -111,6 +117,8 @@ def delete_subcomment(request, subcomment_id):
 @permission_classes([IsAuthenticated])
 def update_subcomment(request, subcomment_id):
     subcomment = get_object_or_404(Subcomment, pk=subcomment_id)
+    if subcomment.author != request.user:
+        return Response({'error': 'You do not have permission to perform this action.'}, status=status.HTTP_403_FORBIDDEN)
     serializer = SubcommentSerializer(subcomment, data=request.data, partial=False)  # Full update
     if serializer.is_valid():
         serializer.save()

--- a/backend/genfit_django/api/tests/test_comment_api.py
+++ b/backend/genfit_django/api/tests/test_comment_api.py
@@ -1,0 +1,158 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+from django.contrib.auth import get_user_model
+from ..models import Forum, Thread, Comment, Subcomment
+
+User = get_user_model()
+
+class CommentAPITests(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username='user',
+            email='user@example.com',
+            password='password123',
+            user_type='User'
+        )
+        self.other_user = User.objects.create_user(
+            username='other',
+            email='other@example.com',
+            password='password123',
+            user_type='User'
+        )
+        self.admin_user = User.objects.create_superuser(
+            username='admin',
+            email='admin@example.com',
+            password='password123',
+            user_type='User'
+        )
+        self.forum = Forum.objects.create(
+            title='Test Forum',
+            description='Test Description',
+            created_by=self.admin_user
+        )
+        self.thread = Thread.objects.create(
+            forum=self.forum,
+            title='Test Thread',
+            content='Test Content',
+            author=self.user
+        )
+        self.comment = Comment.objects.create(
+            thread=self.thread,
+            author=self.user,
+            content='Test Comment'
+        )
+        self.subcomment = Subcomment.objects.create(
+            comment=self.comment,
+            author=self.user,
+            content='Test Subcomment'
+        )
+
+    def test_add_comment(self):
+        """Ensure authenticated user can add a comment"""
+        self.client.force_authenticate(user=self.user)
+        url = reverse('add_comment', args=[self.thread.id])
+        data = {'content': 'New Comment'}
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Comment.objects.count(), 2)
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.comment_count, 1) # Initial comment was created manually, but comment_count defaults to 0 and is not auto-updated on create unless via signal or view. The view updates it.
+        # Wait, the initial comment was created via ORM, so comment_count is 0.
+        # The new comment via API increments it. So it should be 1.
+        # Actually, let's check if there are signals updating comment_count.
+        # Looking at models.py, there are no signals for comment_count.
+        # So manual creation leaves it at 0. API creation adds 1. So total 1.
+        
+    def test_update_comment_author(self):
+        """Ensure author can update their comment"""
+        self.client.force_authenticate(user=self.user)
+        url = reverse('update_comment', args=[self.comment.id])
+        data = {'content': 'Updated Comment'}
+        response = self.client.put(url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.comment.refresh_from_db()
+        self.assertEqual(self.comment.content, 'Updated Comment')
+
+    def test_update_comment_other_user(self):
+        """Ensure other user cannot update comment"""
+        self.client.force_authenticate(user=self.other_user)
+        url = reverse('update_comment', args=[self.comment.id])
+        data = {'content': 'Updated Comment'}
+        response = self.client.put(url, data)
+        # This is expected to fail before the fix
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_delete_comment_author(self):
+        """Ensure author can delete their comment"""
+        self.client.force_authenticate(user=self.user)
+        # Manually set comment_count to 1 since we have one comment
+        self.thread.comment_count = 1
+        self.thread.save()
+        
+        url = reverse('delete_comment', args=[self.comment.id])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(Comment.objects.count(), 0)
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.comment_count, 0)
+
+    def test_delete_comment_other_user(self):
+        """Ensure other user cannot delete comment"""
+        self.client.force_authenticate(user=self.other_user)
+        url = reverse('delete_comment', args=[self.comment.id])
+        response = self.client.delete(url)
+        # This is expected to fail before the fix
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_add_subcomment(self):
+        """Ensure authenticated user can add a subcomment"""
+        self.client.force_authenticate(user=self.user)
+        url = reverse('add_subcomment', args=[self.comment.id])
+        data = {'content': 'New Subcomment'}
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Subcomment.objects.count(), 2)
+        self.comment.refresh_from_db()
+        self.assertEqual(self.comment.subcomment_count, 1)
+
+    def test_update_subcomment_author(self):
+        """Ensure author can update their subcomment"""
+        self.client.force_authenticate(user=self.user)
+        url = reverse('update_subcomment', args=[self.subcomment.id])
+        data = {'content': 'Updated Subcomment'}
+        response = self.client.put(url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.subcomment.refresh_from_db()
+        self.assertEqual(self.subcomment.content, 'Updated Subcomment')
+
+    def test_update_subcomment_other_user(self):
+        """Ensure other user cannot update subcomment"""
+        self.client.force_authenticate(user=self.other_user)
+        url = reverse('update_subcomment', args=[self.subcomment.id])
+        data = {'content': 'Updated Subcomment'}
+        response = self.client.put(url, data)
+        # This is expected to fail before the fix
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_delete_subcomment_author(self):
+        """Ensure author can delete their subcomment"""
+        self.client.force_authenticate(user=self.user)
+        self.comment.subcomment_count = 1
+        self.comment.save()
+        
+        url = reverse('delete_subcomment', args=[self.subcomment.id])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(Subcomment.objects.count(), 0)
+        self.comment.refresh_from_db()
+        self.assertEqual(self.comment.subcomment_count, 0)
+
+    def test_delete_subcomment_other_user(self):
+        """Ensure other user cannot delete subcomment"""
+        self.client.force_authenticate(user=self.other_user)
+        url = reverse('delete_subcomment', args=[self.subcomment.id])
+        response = self.client.delete(url)
+        # This is expected to fail before the fix
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/backend/genfit_django/api/tests/test_forum_api.py
+++ b/backend/genfit_django/api/tests/test_forum_api.py
@@ -1,0 +1,120 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+from django.contrib.auth import get_user_model
+from ..models import Forum, Thread
+
+User = get_user_model()
+
+class ForumAPITests(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.admin_user = User.objects.create_superuser(
+            username='admin',
+            email='admin@example.com',
+            password='password123',
+            user_type='User'
+        )
+        self.regular_user = User.objects.create_user(
+            username='user',
+            email='user@example.com',
+            password='password123',
+            user_type='User'
+        )
+        self.forum_data = {
+            'title': 'Test Forum',
+            'description': 'This is a test forum'
+        }
+        self.forum = Forum.objects.create(
+            title='Existing Forum',
+            description='Existing description',
+            created_by=self.admin_user
+        )
+
+    def test_create_forum_admin(self):
+        """Ensure admin can create a forum"""
+        self.client.force_authenticate(user=self.admin_user)
+        url = reverse('forum-list')
+        response = self.client.post(url, self.forum_data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Forum.objects.count(), 2)
+        self.assertEqual(Forum.objects.get(id=response.data['id']).title, 'Test Forum')
+
+    def test_create_forum_regular_user(self):
+        """Ensure regular user cannot create a forum"""
+        self.client.force_authenticate(user=self.regular_user)
+        url = reverse('forum-list')
+        response = self.client.post(url, self.forum_data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_create_forum_unauthenticated(self):
+        """Ensure unauthenticated user cannot create a forum"""
+        url = reverse('forum-list')
+        response = self.client.post(url, self.forum_data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_list_forums(self):
+        """Ensure anyone can list forums"""
+        url = reverse('forum-list')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+    def test_retrieve_forum(self):
+        """Ensure anyone can retrieve a specific forum"""
+        url = reverse('forum-detail', args=[self.forum.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['title'], self.forum.title)
+
+    def test_update_forum_admin(self):
+        """Ensure admin can update a forum"""
+        self.client.force_authenticate(user=self.admin_user)
+        url = reverse('forum-detail', args=[self.forum.id])
+        updated_data = {'title': 'Updated Forum Title', 'description': 'Updated description'}
+        response = self.client.put(url, updated_data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.forum.refresh_from_db()
+        self.assertEqual(self.forum.title, 'Updated Forum Title')
+
+    def test_update_forum_regular_user(self):
+        """Ensure regular user cannot update a forum"""
+        self.client.force_authenticate(user=self.regular_user)
+        url = reverse('forum-detail', args=[self.forum.id])
+        updated_data = {'title': 'Updated Forum Title'}
+        response = self.client.put(url, updated_data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_delete_forum_admin(self):
+        """Ensure admin can delete a forum"""
+        self.client.force_authenticate(user=self.admin_user)
+        url = reverse('forum-detail', args=[self.forum.id])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(Forum.objects.count(), 0)
+
+    def test_delete_forum_regular_user(self):
+        """Ensure regular user cannot delete a forum"""
+        self.client.force_authenticate(user=self.regular_user)
+        url = reverse('forum-detail', args=[self.forum.id])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_thread_count(self):
+        """Test that thread_count property is correct"""
+        Thread.objects.create(
+            forum=self.forum,
+            title='Thread 1',
+            content='Content 1',
+            author=self.regular_user
+        )
+        Thread.objects.create(
+            forum=self.forum,
+            title='Thread 2',
+            content='Content 2',
+            author=self.regular_user
+        )
+        
+        url = reverse('forum-detail', args=[self.forum.id])
+        response = self.client.get(url)
+        self.assertEqual(response.data['thread_count'], 2)

--- a/backend/genfit_django/api/tests/test_forum_permissions.py
+++ b/backend/genfit_django/api/tests/test_forum_permissions.py
@@ -1,0 +1,71 @@
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+from ..permissions import IsAuthorOrReadOnly
+from ..models import Thread, Forum
+from django.contrib.auth import get_user_model
+from unittest.mock import Mock
+
+User = get_user_model()
+
+class ForumPermissionsTest(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.permission = IsAuthorOrReadOnly()
+        self.user = User.objects.create_user(
+            username='user',
+            email='user@example.com',
+            password='password123',
+            user_type='User'
+        )
+        self.other_user = User.objects.create_user(
+            username='other',
+            email='other@example.com',
+            password='password123',
+            user_type='User'
+        )
+        self.admin_user = User.objects.create_superuser(
+            username='admin',
+            email='admin@example.com',
+            password='password123',
+            user_type='User'
+        )
+        self.forum = Forum.objects.create(
+            title='Test Forum',
+            created_by=self.admin_user
+        )
+        self.thread = Thread.objects.create(
+            forum=self.forum,
+            title='Test Thread',
+            content='Content',
+            author=self.user
+        )
+
+    def test_read_access_allowed(self):
+        """Ensure read access is allowed for anyone"""
+        request = self.factory.get('/')
+        request.user = self.other_user
+        self.assertTrue(self.permission.has_object_permission(request, None, self.thread))
+
+    def test_write_access_author(self):
+        """Ensure write access is allowed for author"""
+        request = self.factory.put('/')
+        request.user = self.user
+        self.assertTrue(self.permission.has_object_permission(request, None, self.thread))
+
+    def test_write_access_other_user(self):
+        """Ensure write access is denied for other user"""
+        request = self.factory.put('/')
+        request.user = self.other_user
+        self.assertFalse(self.permission.has_object_permission(request, None, self.thread))
+
+    def test_delete_access_author(self):
+        """Ensure delete access is allowed for author"""
+        request = self.factory.delete('/')
+        request.user = self.user
+        self.assertTrue(self.permission.has_object_permission(request, None, self.thread))
+
+    def test_delete_access_other_user(self):
+        """Ensure delete access is denied for other user"""
+        request = self.factory.delete('/')
+        request.user = self.other_user
+        self.assertFalse(self.permission.has_object_permission(request, None, self.thread))

--- a/backend/genfit_django/api/tests/test_thread_api.py
+++ b/backend/genfit_django/api/tests/test_thread_api.py
@@ -1,0 +1,120 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+from django.contrib.auth import get_user_model
+from ..models import Forum, Thread
+
+User = get_user_model()
+
+class ThreadAPITests(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username='user',
+            email='user@example.com',
+            password='password123',
+            user_type='User'
+        )
+        self.other_user = User.objects.create_user(
+            username='other',
+            email='other@example.com',
+            password='password123',
+            user_type='User'
+        )
+        self.admin_user = User.objects.create_superuser(
+            username='admin',
+            email='admin@example.com',
+            password='password123',
+            user_type='User'
+        )
+        self.forum = Forum.objects.create(
+            title='Test Forum',
+            description='Test Description',
+            created_by=self.admin_user
+        )
+        self.thread = Thread.objects.create(
+            forum=self.forum,
+            title='Test Thread',
+            content='Test Content',
+            author=self.user
+        )
+        self.thread_data = {
+            'title': 'New Thread',
+            'content': 'New Content',
+            'forum': self.forum.id
+        }
+
+    def test_create_thread_authenticated(self):
+        """Ensure authenticated user can create a thread"""
+        self.client.force_authenticate(user=self.user)
+        url = reverse('thread-list')
+        response = self.client.post(url, self.thread_data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Thread.objects.count(), 2)
+        self.assertEqual(Thread.objects.last().author, self.user)
+
+    def test_create_thread_unauthenticated(self):
+        """Ensure unauthenticated user cannot create a thread"""
+        url = reverse('thread-list')
+        response = self.client.post(url, self.thread_data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_list_threads(self):
+        """Ensure threads can be listed"""
+        url = reverse('thread-list')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+    def test_retrieve_thread_increments_view_count(self):
+        """Ensure retrieving a thread increments view_count"""
+        url = reverse('thread-detail', args=[self.thread.id])
+        initial_views = self.thread.view_count
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.view_count, initial_views + 1)
+
+    def test_update_thread_author(self):
+        """Ensure author can update their thread"""
+        self.client.force_authenticate(user=self.user)
+        url = reverse('thread-detail', args=[self.thread.id])
+        updated_data = {'title': 'Updated Title', 'content': 'Updated Content', 'forum': self.forum.id}
+        response = self.client.put(url, updated_data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.title, 'Updated Title')
+
+    def test_partial_update_thread_author(self):
+        """Ensure author can partially update their thread"""
+        self.client.force_authenticate(user=self.user)
+        url = reverse('thread-detail', args=[self.thread.id])
+        updated_data = {'title': 'Partially Updated Title'}
+        response = self.client.patch(url, updated_data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.title, 'Partially Updated Title')
+        self.assertEqual(self.thread.content, 'Test Content')
+
+    def test_update_thread_other_user(self):
+        """Ensure other user cannot update thread"""
+        self.client.force_authenticate(user=self.other_user)
+        url = reverse('thread-detail', args=[self.thread.id])
+        updated_data = {'title': 'Updated Title', 'content': 'Updated Content', 'forum': self.forum.id}
+        response = self.client.put(url, updated_data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_delete_thread_author(self):
+        """Ensure author can delete their thread"""
+        self.client.force_authenticate(user=self.user)
+        url = reverse('thread-detail', args=[self.thread.id])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(Thread.objects.count(), 0)
+
+    def test_delete_thread_other_user(self):
+        """Ensure other user cannot delete thread"""
+        self.client.force_authenticate(user=self.other_user)
+        url = reverse('thread-detail', args=[self.thread.id])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/backend/genfit_django/api/tests/test_vote_api.py
+++ b/backend/genfit_django/api/tests/test_vote_api.py
@@ -1,0 +1,140 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+from django.contrib.auth import get_user_model
+from ..models import Forum, Thread, Comment, Subcomment, Vote
+
+User = get_user_model()
+
+class VoteAPITests(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            username='user',
+            email='user@example.com',
+            password='password123',
+            user_type='User'
+        )
+        self.admin_user = User.objects.create_superuser(
+            username='admin',
+            email='admin@example.com',
+            password='password123',
+            user_type='User'
+        )
+        self.forum = Forum.objects.create(
+            title='Test Forum',
+            description='Test Description',
+            created_by=self.admin_user
+        )
+        self.thread = Thread.objects.create(
+            forum=self.forum,
+            title='Test Thread',
+            content='Test Content',
+            author=self.user
+        )
+        self.comment = Comment.objects.create(
+            thread=self.thread,
+            author=self.user,
+            content='Test Comment'
+        )
+        self.subcomment = Subcomment.objects.create(
+            comment=self.comment,
+            author=self.user,
+            content='Test Subcomment'
+        )
+
+    def test_upvote_thread(self):
+        """Ensure user can upvote a thread"""
+        self.client.force_authenticate(user=self.user)
+        url = reverse('create_vote')
+        data = {
+            'content_type': 'THREAD',
+            'object_id': self.thread.id,
+            'vote_type': 'UPVOTE'
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.like_count, 1)
+        self.assertTrue(Vote.objects.filter(user=self.user, object_id=self.thread.id, vote_type='UPVOTE').exists())
+
+    def test_downvote_thread(self):
+        """Ensure user can downvote a thread"""
+        self.client.force_authenticate(user=self.user)
+        url = reverse('create_vote')
+        data = {
+            'content_type': 'THREAD',
+            'object_id': self.thread.id,
+            'vote_type': 'DOWNVOTE'
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.like_count, 0) # Downvote doesn't increment like_count
+        self.assertTrue(Vote.objects.filter(user=self.user, object_id=self.thread.id, vote_type='DOWNVOTE').exists())
+
+    def test_change_vote(self):
+        """Ensure changing vote updates like_count correctly"""
+        self.client.force_authenticate(user=self.user)
+        url = reverse('create_vote')
+        
+        # First Upvote
+        data = {'content_type': 'THREAD', 'object_id': self.thread.id, 'vote_type': 'UPVOTE'}
+        self.client.post(url, data)
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.like_count, 1)
+        
+        # Change to Downvote
+        data['vote_type'] = 'DOWNVOTE'
+        self.client.post(url, data)
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.like_count, 0)
+        
+        # Change back to Upvote
+        data['vote_type'] = 'UPVOTE'
+        self.client.post(url, data)
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.like_count, 1)
+
+    def test_delete_vote(self):
+        """Ensure deleting vote updates like_count"""
+        self.client.force_authenticate(user=self.user)
+        
+        # Create vote first
+        Vote.create_or_update_vote(self.user, self.thread, 'UPVOTE')
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.like_count, 1)
+        
+        url = reverse('delete_vote', args=['THREAD', self.thread.id])
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.like_count, 0)
+
+    def test_vote_comment(self):
+        """Ensure user can vote on comment"""
+        self.client.force_authenticate(user=self.user)
+        url = reverse('create_vote')
+        data = {
+            'content_type': 'COMMENT',
+            'object_id': self.comment.id,
+            'vote_type': 'UPVOTE'
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.comment.refresh_from_db()
+        self.assertEqual(self.comment.like_count, 1)
+
+    def test_vote_subcomment(self):
+        """Ensure user can vote on subcomment"""
+        self.client.force_authenticate(user=self.user)
+        url = reverse('create_vote')
+        data = {
+            'content_type': 'SUBCOMMENT',
+            'object_id': self.subcomment.id,
+            'vote_type': 'UPVOTE'
+        }
+        response = self.client.post(url, data)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.subcomment.refresh_from_db()
+        self.assertEqual(self.subcomment.like_count, 1)


### PR DESCRIPTION
[Corresponding issue ](https://github.com/bounswe/bounswe2025group2/issues/528)

### PR NAME
feat: Add comprehensive Forum API tests and fix permission issues

#### Description
This PR implements comprehensive unit tests for the Forum, Thread, Comment, Subcomment, and Vote API endpoints as requested in Issue #528. It also fixes a critical security issue where non-authors could update or delete comments and subcomments.

#### Changes Made
- Created  to test Forum CRUD operations.
- Created  to test Thread CRUD operations and permissions.
- Created  to test Comment/Subcomment CRUD and permissions.
- Created  to test the voting system.
- Created  to test  permission.
- Added permission checks to , , , and  views.

#### Features
- [x] Comprehensive test coverage for Forum API
- [x] Security fix for Comment/Subcomment permissions

#### API Endpoints
- No new endpoints added.
- Fixed permissions for:
    - PUT 
    - DELETE 
    - PUT 
    - DELETE 

#### Technical Details
- Used  and  for testing.
- Ensured all tests pass with .
- Verified that existing notification tests still pass.

#### Testing
- Ran  -> All 40 tests passed.
- Ran  -> All 4 tests passed.

#### Dependencies
- No new dependencies.

#### Documentation
- No documentation updates needed.

#### Checklist
- [x] My code follows style guidelines
- [x] I have performed self-review
- [x] I have commented complex code
- [x] I have updated documentation
- [x] I have updated requirements.txt
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged
