### PR TITLE
RTBF done in backend and frontend

### DIFF
--- a/backend/genfit_django/api/urls.py
+++ b/backend/genfit_django/api/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
     path('csrf-token/', views.get_csrf_token, name='get_csrf_token'),
     path('change-password/', views.change_password, name='change_password'),
     path('delete-account/', views.delete_account, name='delete_account'),
+    path('user/rtbf/', views.rtbf_delete_user_data, name='rtbf_delete_user_data'),
 
     # Notifications
     path('notifications/', views.get_user_notifications, name='get_notifications'),

--- a/backend/genfit_django/api_documentations/login_reg.md
+++ b/backend/genfit_django/api_documentations/login_reg.md
@@ -165,3 +165,34 @@ Logs out the currently authenticated user.
     "message": "Logged out successfully"
   }
   ```
+
+### Delete Personal Data (RTBF) 🔒
+
+Permanently deletes all personal data and the user account (Right to be Forgotten).
+
+- **URL**: `/user/rtbf/`
+- **Method**: `DELETE`
+- **Auth Required**: Yes
+- **Permissions**: IsAuthenticated
+
+**Description**:
+
+Deletes goals, forum content (threads, comments, subcomments, votes and their children), direct chats and messages, AI tutor chats/responses/messages, notifications, mentor relationships, challenges and participation progress, profile information that belongs to user; and the user account itself. This action is irreversible.
+
+**Request Body**: None
+
+**Response**:
+
+- **Success (200 OK)**
+  ```json
+  {
+    "detail": "User data deleted"
+  }
+  ```
+
+- **Error (403 Forbidden)**
+  ```json
+  {
+    "error": "Authentication required"
+  }
+  ```


### PR DESCRIPTION
[Corresponding issue for backend changes](https://github.com/bounswe/bounswe2025group2/issues/372)  
[Corresponding issue for web-frontend changes](https://github.com/bounswe/bounswe2025group2/issues/670)

**PR NAME**
- Implement RTBF: Backend endpoint and Frontend Settings UI

**Description**
- Adds Right to be Forgotten support end-to-end.
- Backend provides a single authenticated endpoint to permanently delete all user data and the account.
- Frontend exposes a “Delete Personal Data” button under Settings with a confirmation flow, consistent styling, and safe redirect/logout behavior.

**Changes Made**
- Backend
  - Added `DELETE /api/user/rtbf/` that deletes goals, forum content (threads, comments, subcomments, votes), direct chats/messages, AI tutor chats/responses/messages, notifications, mentor relationships, challenges/participation progress, profile info, and user account.
  - Wrapped deletion in a `transaction.atomic()` for consistency.
  - Fixed import to `from chat.models import DirectChat, DirectMessage` to avoid relative import errors.
  - Registered the endpoint in `api/urls.py`.
- Frontend
  - Settings page adds a “Data & Privacy” section with “Delete Personal Data” button and a confirmation dialog explaining irreversible deletion.
  - RTBF request sent via `GFapi.delete('/api/user/rtbf/')`, then logout, then redirect to `/auth`.
  - On logout errors (expected when account is deleted), the redirect proceeds anyway.
  - Styling aligned with existing `save-btn`/`cancel-btn`; consistent with the app’s style.
- Documentation
  - Extended `api_documentations/login_reg.md` with “Delete Personal Data (RTBF)” endpoint details.

**Features**
- [x] Backend RTBF deletion endpoint for authenticated users
- [x] Frontend Settings UI to trigger deletion with confirmation
- [x] Safe redirect/logout flow post-deletion
- [x] Documentation updated for new endpoint

**API Endpoints**
- DELETE `/api/user/rtbf/`: Permanently delete all personal data and the user account
- POST `/api/logout/`: Logs out the current user (front-end attempts logout after RTBF and proceeds to redirect even if logout returns 403)

**Technical Details**
- Backend deletion uses direct filters and `ContentType` for votes to clean up attached likes across threads/comments/subcomments.
- Order of operations ensures related children are removed:
  - Votes by user
  - Votes attached to user’s threads, comments, and subcomments
  - Subcomments/comments/threads where user is the author
  - Direct messages and chats (cascade via `on_delete=CASCADE`)
  - AI tutor artifacts (chats/responses/messages)
  - Notifications (recipient or sender)
  - Mentor relationships (sender/receiver/mentor/mentee)
  - Challenges created by user and their participants; user participation
  - Profile record
  - User record
- Frontend leverages `GFapi` for CSRF-compliant requests and handles logout gracefully (ignore error when the account is gone).

**Testing**
- Backend
  - Verified `DELETE /api/user/rtbf/` returns 200 and subsequent user endpoints return 403.
  - Checked DB for no remaining user-linked rows in goals, threads, comments, subcomments, votes, chats, AI tutor tables, notifications, relationships, challenges/participants, profile, and user.
- Frontend
  - In Settings → Data & Privacy → “Delete Personal Data”, observed dialog, deletion, logout attempt, and redirect to `/auth`.
  - Confirmed styling consistency and pointer cursor on buttons.
  - Verified post-deletion authenticated endpoints return 403 and UI is redirected away.

**Dependencies**
- None

**Documentation**
- Updated `backend/genfit_django/api_documentations/login_reg.md` to include:
  - “Delete Personal Data (RTBF)” endpoint with method, auth, permissions, description, and sample responses

**Checklist**
- [x] My code follows style guidelines
- [x] I have performed self-review
- [x] I have commented complex code
- [x] I have updated documentation
- [ ] I have updated requirements.txt
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged