### PR TITLE
Deadline type added home page mobile

### DIFF
--- a/mobile_frontend/src/Pages/Home.tsx
+++ b/mobile_frontend/src/Pages/Home.tsx
@@ -626,9 +626,11 @@ const Home = () => {
                           {deadline.title}
                         </CustomText>
                         <View style={styles.deadlineMeta}>
-                          <Chip mode="flat" compact style={styles.deadlineTypeChip}>
-                            {deadline.type}
-                          </Chip>
+                          <View style={[styles.deadlineTypeBadge, { backgroundColor: customTheme.colors.navBar }]}>
+                            <CustomText style={[styles.deadlineTypeText, { color: customTheme.colors.subText }]}>
+                              {deadline.type}
+                            </CustomText>
+                          </View>
                           <CustomText style={[styles.deadlineDate, { color: customTheme.colors.subText }]}>
                             {deadline.daysUntil === 0 ? 'Today' :
                              deadline.daysUntil === 1 ? 'Tomorrow' :
@@ -1028,8 +1030,15 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 8,
   },
-  deadlineTypeChip: {
-    height: 20,
+  deadlineTypeBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 8,
+  },
+  deadlineTypeText: {
+    fontSize: 11,
+    fontWeight: '500',
+    textTransform: 'capitalize',
   },
   deadlineDate: {
     fontSize: 12,


### PR DESCRIPTION
[Corresponding issue ](https://github.com/bounswe/bounswe2025group2/issues/692)

### Fix Deadline Type Rendering in Home Page

#### Description
This PR addresses a visual bug in the "Upcoming Deadlines" section of the Home page where deadline types ("goal" or "challenge") were rendering as obscure dots instead of readable text. This was caused by the `Chip` component not behaving as expected in the current layout. The fix involves replacing the `Chip` component with a custom-styled badge to ensure the text labels are clearly visible.

#### Changes Made
- Removed the `Chip` component from the `renderDeadlineItem` function in `Home.tsx`.
- Implemented a custom badge using `View` and `CustomText` components.
- Added new styles: `deadlineTypeBadge` (for background styling) and `deadlineTypeText` (for text styling).
- Hardcoded the capitalization logic to ensure consistent display (e.g., "Goal", "Challenge").

#### Features
- [x] **Visual Fix:** Deadline items now clearly show a text badge indicating their type.
- [x] **Styling:** The new badge matches the application's design system using existing color tokens.
- [x] **Readability:** Users can now instantly distinguish between goal and challenge deadlines.

#### API Endpoints
- N/A (UI-only change).

#### Technical Details
- **Issue Root Cause:** The UI library's `Chip` component was collapsing or defaulting to a "dot" mode in the specific nested view structure of the timeline.
- **Solution:** A lightweight custom implementation allows for full control over dimensions and text rendering, eliminating the display issue.

#### Testing
- Verified that "Upcoming Deadlines" no longer displays dots.
- Confirmed that "goal" items show a "Goal" badge.
- Confirmed that "challenge" items show a "Challenge" badge.
- Checked layout alignment on different screen sizes to ensure the badge doesn't break the row layout.

#### Dependencies
- None

#### Documentation
- N/A

#### Checklist
- [x] My code follows style guidelines
- [x] I have performed self-review
- [x] I have commented complex code

- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged