### PR TITLE
fix: exercise prefix

### DIFF
--- a/Web_Frontend/genfit_frontend/src/pages/knowledge-hub/GlossaryPage.tsx
+++ b/Web_Frontend/genfit_frontend/src/pages/knowledge-hub/GlossaryPage.tsx
@@ -22,7 +22,8 @@ interface GlossaryExercise {
   tips?: string;
 }
 
-const glossaryExercises: GlossaryExercise[] = [
+// Hard-coded exercise list (local glossary, matches web \"Exercise Library\" tab)
+export const glossaryExercises: GlossaryExercise[] = [
   {
     id: 1,
     name: 'Push Up',
@@ -53,6 +54,23 @@ const glossaryExercises: GlossaryExercise[] = [
       'Push through your heels to return to standing',
     ],
     tips: 'Keep your chest up and back straight. Don\'t let your knees cave inward.',
+  },
+  {
+    id: 3,
+    name: 'Deadlift',
+    description: 'A compound exercise that targets multiple muscle groups including the back, glutes, and hamstrings.',
+    muscleGroups: ['Back', 'Glutes', 'Hamstrings', 'Core'],
+    difficulty: 'Advanced',
+    equipment: 'Barbell and weights',
+    instructions: [
+      'Stand with feet hip-width apart, bar over mid-foot',
+      'Bend at hips and knees to grip the bar',
+      'Keep back straight and chest up',
+      'Drive through heels to lift the bar',
+      'Stand tall with shoulders back',
+      'Lower the bar by pushing hips back',
+    ],
+    tips: 'Maintain a neutral spine throughout. Start with lighter weights to perfect form.',
   },
   {
     id: 4,
@@ -145,6 +163,22 @@ const glossaryExercises: GlossaryExercise[] = [
       'Lower with control to starting position',
     ],
     tips: 'Keep core tight to protect lower back. Don\'t arch excessively.',
+  },
+  {
+    id: 10,
+    name: 'Romanian Deadlift',
+    description: 'A variation of the deadlift that emphasizes the hamstrings and glutes.',
+    muscleGroups: ['Hamstrings', 'Glutes', 'Back'],
+    difficulty: 'Intermediate',
+    equipment: 'Barbell or dumbbells',
+    instructions: [
+      'Hold weight with arms extended',
+      'Hinge at hips, pushing them back',
+      'Lower weight while keeping legs relatively straight',
+      'Feel stretch in hamstrings',
+      'Return to standing by squeezing glutes',
+    ],
+    tips: 'Keep back straight. Don\'t round your back. Focus on hip hinge movement.',
   },
   // Running-Specific
   {
@@ -1409,6 +1443,22 @@ const glossaryExercises: GlossaryExercise[] = [
     tips: 'Keep back straight. Don\'t round your back. Focus on hip hinge, not squatting.',
   },
   {
+    id: 89,
+    name: 'Lunges',
+    description: 'Stepping forward into lunge position to target legs and glutes unilaterally.',
+    muscleGroups: ['Quadriceps', 'Glutes', 'Hamstrings'],
+    difficulty: 'Beginner',
+    equipment: 'None (or dumbbells for added resistance)',
+    instructions: [
+      'Step forward with one leg',
+      'Lower until both knees at 90 degrees',
+      'Push through front heel to return',
+      'Alternate legs',
+      'Repeat 10-12 times per leg',
+    ],
+    tips: 'Keep front knee behind toes. Maintain upright posture. This improves balance and addresses imbalances.',
+  },
+  {
     id: 90,
     name: 'Calf Raises',
     description: 'Rising onto toes to strengthen calves, important for running, jumping, and overall leg strength.',
@@ -1762,14 +1812,15 @@ export default function GlossaryPage() {
 
   // Handle exercise parameter from URL (for linking from chat)
   useEffect(() => {
-    const exerciseName = searchParams.get('exercise');
-    if (exerciseName) {
+    const exerciseIdParam = searchParams.get('exerciseId');
+    if (exerciseIdParam) {
       // Switch to glossary tab
       setActiveTab('glossary');
       
-      // Find the exercise by name (case-insensitive)
+      // Find the exercise by ID
+      const exerciseId = parseInt(exerciseIdParam, 10);
       const foundExercise = glossaryExercises.find(
-        ex => ex.name.toLowerCase() === exerciseName.toLowerCase()
+        ex => ex.id === exerciseId
       );
 
       if (foundExercise) {


### PR DESCRIPTION
[Corresponding issue ](<link-to-issue>)

### fix: exercise prefix

#### Description
This pull request enhances the chat link parsing system to support both ID-based and name-based exercise links in messages, making it easier to reference exercises in chat and reliably link to the glossary. It also updates the exercise glossary with new entries and improves how exercises are linked from chat to the glossary page.

**Chat Link Parsing Improvements:**

- Added support for parsing `exercise://{id}` links in chat messages, in addition to existing `@ExerciseName` mentions. The parser now recognizes both formats and creates clickable links to the glossary for each. [[1]](diffhunk://#diff-61c8c21b9b2eab8c3e8ee75e724eb32b528e0d7d5e46fdf66dc63eb94e5d1dc6R2-R17) [[2]](diffhunk://#diff-61c8c21b9b2eab8c3e8ee75e724eb32b528e0d7d5e46fdf66dc63eb94e5d1dc6L24-R53) [[3]](diffhunk://#diff-61c8c21b9b2eab8c3e8ee75e724eb32b528e0d7d5e46fdf66dc63eb94e5d1dc6L61-R84)
- Updated the `LinkSegment` interface and parsing logic to distinguish between exercise references by ID and by name, ensuring accurate linking and display. [[1]](diffhunk://#diff-61c8c21b9b2eab8c3e8ee75e724eb32b528e0d7d5e46fdf66dc63eb94e5d1dc6R121) [[2]](diffhunk://#diff-61c8c21b9b2eab8c3e8ee75e724eb32b528e0d7d5e46fdf66dc63eb94e5d1dc6R148-R157)
- Enhanced the rendering function to create links with the correct URL parameter (`exerciseId`) for ID-based links and to gracefully handle cases where an exercise name is not found.

**Utility Functions and Extraction:**

- Added new utility functions to check for and extract exercise IDs from messages, complementing the existing name-based utilities. [[1]](diffhunk://#diff-61c8c21b9b2eab8c3e8ee75e724eb32b528e0d7d5e46fdf66dc63eb94e5d1dc6L175-R236) [[2]](diffhunk://#diff-61c8c21b9b2eab8c3e8ee75e724eb32b528e0d7d5e46fdf66dc63eb94e5d1dc6L196-R271)

**Glossary Data and Linking:**

- Exported the `glossaryExercises` array for use in parsing logic and added several new exercises (e.g., Deadlift, Romanian Deadlift, Lunges) to the glossary data. [[1]](diffhunk://#diff-fcfd8c017d7c2cdcd8cb39ceff86185be4572a622270b62b99a936c450b47282L25-R26) [[2]](diffhunk://#diff-fcfd8c017d7c2cdcd8cb39ceff86185be4572a622270b62b99a936c450b47282R58-R74) [[3]](diffhunk://#diff-fcfd8c017d7c2cdcd8cb39ceff86185be4572a622270b62b99a936c450b47282R167-R182) [[4]](diffhunk://#diff-fcfd8c017d7c2cdcd8cb39ceff86185be4572a622270b62b99a936c450b47282R1445-R1460)
- Updated the glossary page logic to handle the new `exerciseId` URL parameter, enabling direct navigation to an exercise by ID when linked from chat.

