### PR TITLE
Sidebar Rearrange

### DIFF
--- a/Web_Frontend/genfit_frontend/src/components/SideNavigation.tsx
+++ b/Web_Frontend/genfit_frontend/src/components/SideNavigation.tsx
@@ -31,6 +31,28 @@ const defaultNavigationItems: NavigationItem[] = [
     )
   },
   {
+    id: 'profile',
+    label: 'Profile',
+    path: '/profile',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+        <circle cx="12" cy="7" r="4" />
+      </svg>
+    )
+  },
+  {
+    id: 'notifications',
+    label: 'Notifications',
+    path: '/notifications',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path>
+        <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
+      </svg>
+    )
+  },
+  {
     id: 'goals',
     label: 'Goals',
     path: '/goals',
@@ -56,16 +78,6 @@ const defaultNavigationItems: NavigationItem[] = [
     )
   },
   {
-    id: 'forum',
-    label: 'Forum',
-    path: '/forum',
-    icon: (
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
-      </svg>
-    )
-  },
-    {
     id: 'chat',
     label: 'Chat',
     path: '/chatting',
@@ -76,35 +88,12 @@ const defaultNavigationItems: NavigationItem[] = [
     )
   },
   {
-    id: 'notifications',
-    label: 'Notifications',
-    path: '/notifications',
+    id: 'forum',
+    label: 'Forum',
+    path: '/forum',
     icon: (
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-        <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"></path>
-        <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
-      </svg>
-    )
-  },
-  {
-    id: 'profile',
-    label: 'Profile',
-    path: '/profile',
-    icon: (
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-        <circle cx="12" cy="7" r="4" />
-      </svg>
-    )
-  },
-  {
-    id: 'contact',
-    label: 'Contact',
-    path: '/contact',
-    icon: (
-      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-        <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
-        <polyline points="22,6 12,13 2,6"></polyline>
+        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
       </svg>
     )
   },
@@ -116,6 +105,17 @@ const defaultNavigationItems: NavigationItem[] = [
       <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
         <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"></path>
         <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"></path>
+      </svg>
+    )
+  },
+  {
+    id: 'contact',
+    label: 'Contact',
+    path: '/contact',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+        <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
+        <polyline points="22,6 12,13 2,6"></polyline>
       </svg>
     )
   }


### PR DESCRIPTION
This pull request reorganizes the navigation items in the `SideNavigation.tsx` component to improve their order and grouping. It rearranges the positions of  navigation order is more intuitive.

Navigation structure changes:

* Moved `Profile` navigation item with its own icon, placing it near the top of the navigation list.
* Moved the `Notifications` navigation item higher in the list, before `Forum` and `Knowledge Hub`. [[1]](diffhunk://#diff-15cc204f56229fb28c5fb1b5fd5220ff778d0de6702dbf88eb48ae75f135c9f2R33-R54) [[2]](diffhunk://#diff-15cc204f56229fb28c5fb1b5fd5220ff778d0de6702dbf88eb48ae75f135c9f2L79-R107)
* Reordered the `Forum` and `Knowledge Hub` navigation items to appear after `Notifications`, and updated their icons accordingly. [[1]](diffhunk://#diff-15cc204f56229fb28c5fb1b5fd5220ff778d0de6702dbf88eb48ae75f135c9f2L57-L66) [[2]](diffhunk://#diff-15cc204f56229fb28c5fb1b5fd5220ff778d0de6702dbf88eb48ae75f135c9f2L79-R107)